### PR TITLE
fix: block unsupported eslint majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
     labels:
       - 'dependencies'
       - 'npm'
+    ignore:
+      - dependency-name: 'eslint'
+        update-types:
+          - 'version-update:semver-major'
     groups:
       # Group all npm production dependencies together
       # Note: Major version updates are excluded and handled individually


### PR DESCRIPTION
## Summary`n- tell Dependabot to ignore unsupported eslint major bumps until the current Next lint stack supports them`n- prevent recurring non-mergeable ESLint 10 bot PRs in this repo