### PR TITLE
fix(test): scope footer Project link locator to footer element

### DIFF
--- a/tests/property-pages.spec.ts
+++ b/tests/property-pages.spec.ts
@@ -16,7 +16,9 @@ test.describe('Property Pages', () => {
   test('homepage should have Project link in footer navigation', async ({ page }) => {
     await page.goto('/')
 
-    const projectLink = page.locator('a.navbar-link', {
+    // Scope to the footer: header navigation may also contain a Project link,
+    // which would trip Playwright's strict mode with an unscoped locator.
+    const projectLink = page.locator('footer a.navbar-link', {
       hasText: testConfig.propertyPages.footerLinkText,
     })
     await expect(projectLink).toBeVisible()


### PR DESCRIPTION
## Description

`tests/property-pages.spec.ts` uses an unscoped `a.navbar-link` locator to assert the footer's Project link. When a page also renders a Project link in the header navigation — as the rough-draft refresh (#97) does — Playwright strict mode fails with "resolved to 2 elements". This is currently blocking #97's CI.

## Type of Change

- [x] Test addition/update

## Related Issue(s)

Unblocks #97 (its `Test and Build` check fails on this strict-mode violation).

## Changes Made

- Scope the locator to `footer a.navbar-link` so the assertion targets exactly what the test claims to verify (the footer link), regardless of header navigation contents.

## Testing Performed

### Automated Testing

- [x] Verified locally against current `main` (single footer link): passes
- [x] Verified locally against the #97 merged tree (header + footer links): passes
- [x] `npm run build` - Build completes successfully

## Breaking Changes

None / N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNopVpK1nWaykvscKNRQjC)_