### PR TITLE
fix: update asset paths, consent gating, and navigation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,7 +28,7 @@ body {
   margin: 0;
   padding: 0;
   background-color: var(--surface-desk);
-  background-image: url('/img/bodyTile.jpg');
+  background-image: var(--body-tile-url);
   color: var(--ink);
 }
 
@@ -57,7 +57,7 @@ body {
     radial-gradient(ellipse at 18% 14%, rgba(240, 222, 186, 0.22), transparent 38%),
     radial-gradient(ellipse at 78% 72%, rgba(168, 161, 144, 0.1), transparent 42%),
     radial-gradient(ellipse at 52% 88%, rgba(240, 222, 186, 0.1), transparent 28%),
-    url('/img/bookletTile.jpg'), var(--paper-base);
+    var(--booklet-tile-url), var(--paper-base);
   padding: 10px;
   max-width: 850px;
   box-shadow:
@@ -214,7 +214,7 @@ body {
   font-size: 2.2rem;
   font-family: var(--font-modern-antiqua), sans-serif;
   text-align: center;
-  background-image: url('/img/goldBtn.png');
+  background-image: var(--gold-button-url);
   background-size: 100% 100%;
   background-position: center;
   background-repeat: no-repeat;
@@ -300,7 +300,7 @@ body {
 .about-section h3 {
   font-size: 1.8rem;
   color: var(--ink);
-  margin: 5 0 10px 0;
+  margin: 5px 0 10px 0;
   font-weight: bold;
   margin-bottom: 4px;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,11 @@ import { Modern_Antiqua } from 'next/font/google'
 
 // Get basePath for GitHub Pages deployment
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
+const globalAssetVars = {
+  '--body-tile-url': `url('${basePath}/img/bodyTile.jpg')`,
+  '--booklet-tile-url': `url('${basePath}/img/bookletTile.jpg')`,
+  '--gold-button-url': `url('${basePath}/img/goldBtn.png')`,
+} as React.CSSProperties
 
 const modernAntiqua = Modern_Antiqua({
   weight: '400',
@@ -57,7 +62,7 @@ export const metadata: Metadata = {
       'Modern sanctuaries for open-source developers, researchers, and creators to focus on deep work and collaboration.',
     images: [
       {
-        url: '/img/logo.png',
+        url: `${basePath}/img/logo.png`,
         width: 800,
         height: 600,
         alt: 'Techno-Monasteries',
@@ -70,7 +75,7 @@ export const metadata: Metadata = {
     title: 'Techno-Monasteries | A Sanctuary for Open-Source',
     description:
       'Modern sanctuaries for open-source developers, researchers, and creators to focus on deep work and collaboration.',
-    images: ['/img/logo.png'],
+    images: [`${basePath}/img/logo.png`],
   },
   icons: {
     icon: [{ url: `${basePath}/img/favicon.png`, type: 'image/png', sizes: '32x32' }],
@@ -106,11 +111,12 @@ export default function RootLayout({
           novaFlat.variable,
           modernAntiqua.variable,
         ].join(' ')}
+        style={globalAssetVars}
         suppressHydrationWarning={true}
       >
         <GoogleTagManagerNoScript />
         <div className="booklet-page">
-          <div className="booklet-frame ">
+          <div className="booklet-frame">
             <Header />
             {children}
             <Footer />

--- a/src/components/about-page/index.tsx
+++ b/src/components/about-page/index.tsx
@@ -174,8 +174,13 @@ const AboutPage: React.FC = () => {
                 and stay updated on our progress.
               </p>
               <div style={{ textAlign: 'center' }}>
-                <a href="https://discord.gg/T8dxSgZS2J" target="_blank" rel="noopener noreferrer">
-                  <button className="gildedButton">Join our Discord</button>
+                <a
+                  className="gildedButton"
+                  href="https://discord.gg/T8dxSgZS2J"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Join our Discord
                 </a>
               </div>
             </section>

--- a/src/components/active-projects-page/index.tsx
+++ b/src/components/active-projects-page/index.tsx
@@ -32,14 +32,13 @@ const ActiveProjectsPage: React.FC = () => {
         </p>
 
         {/* Property Cards */}
-        <div className="twoCol" style={{ marginTop: '40px', gap: '20px' }}>
+        <div style={{ marginTop: '40px', gap: '20px' }}>
           {/* Sigel PA Card */}
           <div
-            className="innerCol"
             style={{
               backgroundColor: 'rgba(200, 195, 180, 0.4)',
               padding: '20px',
-              border: '2px solid var(--brown)',
+              border: '2px solid var(--line-color)',
             }}
           >
             <div className="pageSectionTitle" style={{ marginBottom: '10px' }}>
@@ -130,11 +129,10 @@ const ActiveProjectsPage: React.FC = () => {
 
           {/* Nederland CO Card */}
           <div
-            className="innerCol"
             style={{
               backgroundColor: 'rgba(200, 195, 180, 0.4)',
               padding: '20px',
-              border: '2px solid var(--brown)',
+              border: '2px solid var(--line-color)',
             }}
           >
             <div className="pageSectionTitle" style={{ marginBottom: '10px' }}>

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -26,6 +26,9 @@ const Header: React.FC = () => {
         <Link href="/about" className="navbar-link">
           About
         </Link>
+        <Link href="/economic-models" className="navbar-link">
+          Economic Models
+        </Link>
       </nav>
       {/* Header with logo, title and tagline */}
       <div className="header">

--- a/src/components/home-page/index.tsx
+++ b/src/components/home-page/index.tsx
@@ -82,8 +82,13 @@ const HomePage: React.FC = () => {
               progress, share ideas, and help shape the first Techno-Monastery.
             </p>
             <div style={{ textAlign: 'center' }}>
-              <a href="https://discord.gg/T8dxSgZS2J" target="_blank" rel="noopener noreferrer">
-                <button className="gildedButton">Join our Discord</button>
+              <a
+                className="gildedButton"
+                href="https://discord.gg/T8dxSgZS2J"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Join our Discord
               </a>
             </div>
           </div>

--- a/src/components/nederland-co-page/index.tsx
+++ b/src/components/nederland-co-page/index.tsx
@@ -79,7 +79,7 @@ const NederlandCoPage: React.FC = () => {
                 ['Wildfire Zone', 'Boulder County Zone 1 (HIGH risk)'],
                 ['Est. Phase 1 Cost', '$2,000,000-$3,500,000'],
               ].map(([label, value]) => (
-                <tr key={label} style={{ borderBottom: '1px solid var(--brown)' }}>
+                <tr key={label} style={{ borderBottom: '1px solid var(--line-color)' }}>
                   <th
                     scope="row"
                     style={{ padding: '8px', fontWeight: 'bold', width: '35%', textAlign: 'left' }}

--- a/src/components/sigel-pa-page/index.tsx
+++ b/src/components/sigel-pa-page/index.tsx
@@ -93,7 +93,7 @@ const SigelPaPage: React.FC = () => {
                 ['Site', '~70 acres of farmland and woodland'],
                 ['Arrangement', 'Nonprofit partnership with charity lease'],
               ].map(([label, value]) => (
-                <tr key={label} style={{ borderBottom: '1px solid var(--brown)' }}>
+                <tr key={label} style={{ borderBottom: '1px solid var(--line-color)' }}>
                   <th
                     scope="row"
                     style={{ padding: '8px', fontWeight: 'bold', width: '35%', textAlign: 'left' }}


### PR DESCRIPTION
## Summary

This PR fixes shared asset paths for GitHub Pages/basePath deployments, adds the Economic Models page to the top navigation, and updates a few shared site-level SEO/consent details.

## What changed

- made shared CSS image URLs basePath-aware
- updated shared metadata image URLs to respect basePath
- added `Economic Models` to the header navigation
- corrected `robots.txt` to point to the live sitemap domain
- added missing live routes to `sitemap.ts`
- gated GTM loading on stored cookie consent
- fixed two formatting issues that were blocking commit hooks

## Verification

- `prettier --check .`
- `eslint`

## Notes

- lint still reports existing warnings for `img` usage and an unused `Testimonials` component warning
- full build was not verified in the restricted environment because Google Fonts fetches may fail without outbound network access

