### PR TITLE
fix: remove stale public/CNAME (no Pages custom-domain binding)

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,0 @@
-technomonasteries.org


### PR DESCRIPTION
FreeForCharity/FFC-Cloudflare-Automation#740: this repo has NO Pages custom domain bound but carried a stale CNAME file (template leftover) — the build targeted a host it does not serve. Removing it: the site builds for its default Pages URL and the smoke engine checks it in pre-cutover default mode. When the domain is ready, cutover sets both the binding and this file together.